### PR TITLE
Remove Dockerfile Apt-get cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-suggests --no-install-recommends \
+        build-essential \
         libldap2-dev \
         libsasl2-dev \
         python3-dev \


### PR DESCRIPTION
Ensure that the Dockerfile does display the installed Packages better and remove apt-get cache to make the Image smaller.