### PR TITLE
Avoid trying to enable DELETED Vaultwarden Users

### DIFF
--- a/vaultwarden_user_sync/compare.py
+++ b/vaultwarden_user_sync/compare.py
@@ -176,7 +176,7 @@ class SyncResult:
 
         # We want to enable users who are currently disabled both in our local state and in Vaultwarden
         # and appear in the source email list again
-        enabled_emails = (ma_user_emails_disabled.union(vw_user_emails_disabled)).intersection(
+        enabled_emails = (ma_user_emails_disabled.intersection(vw_user_emails_disabled)).intersection(
             source_email_addresses)
         change_set.enable_user_ids = {ma_id_by_email[ue] for ue in enabled_emails}
 


### PR DESCRIPTION
This pull request changes the way to merge the two disabled email lists (from local and from Vaultwarden) to avoid errors where an email is DELETED from Vaultwarden and is added to the enabled_emails list.

This should resolve the issue: https://github.com/sirtoobii/vaultwarden_ldap_sync/issues/17