### PR TITLE
Handle DELETED users

### DIFF
--- a/vaultwarden_user_sync/backends/localstore.py
+++ b/vaultwarden_user_sync/backends/localstore.py
@@ -92,6 +92,16 @@ class LocalStore:
                                       (user_state, time.time(), vw_user_id))
             self.con.commit()
 
+    def get_user_state(self, vw_user_id: str):
+        """
+        Get user state in localstore
+        :param vw_user_id: Vaultwarden User ID
+        :return: None
+        """
+        res = self.con.cursor().execute('SELECT state FROM Users WHERE vw_user_id = ?', (vw_user_id,))
+        for state in res.fetchone():
+            return state
+
     def update_vw_email(self, vw_user_id: str, new_vw_email: str):
         """
         Update vaultwarden email (after user updated his email in vaultwarden)

--- a/vaultwarden_user_sync/sync.py
+++ b/vaultwarden_user_sync/sync.py
@@ -124,9 +124,10 @@ if __name__ == '__main__':
 
             for user_id in sync_result.user_ids_vanished_in_vw:
                 if not is_dry_run:
-                    ls.set_user_state(user_id, 'DELETED')
-                logging.info(
-                    f"{log_prefix} Set state to DELETED for: {sync_result.get_ma_user_by_id(user_id).invite_email}")
+                    if ls.get_user_state(user_id) != 'DELETED':
+                        ls.set_user_state(user_id, 'DELETED')
+                        logging.info(
+                            f"{log_prefix} Set state to DELETED for: {sync_result.get_ma_user_by_id(user_id).invite_email}")
 
             for user_id in sync_result.user_ids_disabled_in_vw:
                 if not is_dry_run:


### PR DESCRIPTION
Manages users deleted from Vaultwarden. This avoids spamming "Set state to DELETED" for each deleted user on every reboot.